### PR TITLE
send one alert email only per outage

### DIFF
--- a/Restless.Tests/Services/EmailAlertServiceTests.cs
+++ b/Restless.Tests/Services/EmailAlertServiceTests.cs
@@ -6,11 +6,6 @@ using Newtonsoft.Json.Linq;
 using Restless.Config;
 using Restless.Interfaces;
 using Restless.Services;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Restless.Tests.Services
 {

--- a/Restless.Tests/Services/HealthCheckServiceTests.cs
+++ b/Restless.Tests/Services/HealthCheckServiceTests.cs
@@ -69,8 +69,8 @@ namespace Restless.Tests.Services
 
             var target = new PingTarget
             {
-                Name = "Test API",
-                Url = "https://api.test.com",
+                Name = "Test API2",
+                Url = "https://api.test2.com",
                 MaxRetries = 1
             };
 
@@ -82,7 +82,96 @@ namespace Restless.Tests.Services
             await service.PingAsync(target, CancellationToken.None);
 
             // Assert
-            emailService.Verify(x => x.SendDownAlertAsync(It.Is<PingTarget>(t => t.Name == "Test API")), Times.Once);
+            emailService.Verify(x => x.SendDownAlertAsync(It.Is<PingTarget>(t => t.Url == "https://api.test2.com")), Times.Once);
+        }
+
+        [Fact]
+        public async Task PingAsync_ShouldNotSendDuplicateEmails_IfServiceRemainsDown()
+        {
+            // Arrange
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError)); // Always down
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            var emailService = new Mock<IEmailAlertService>();
+            var logger = Mock.Of<ILogger<HealthCheckService>>();
+
+            var target = new PingTarget
+            {
+                Name = "Test API",
+                Url = "https://api.test.com",
+                MaxRetries = 1
+            };
+
+            var options = Options.Create(new List<PingTarget> { target });
+
+            var service = new HealthCheckService(httpClientFactory.Object, options, emailService.Object, logger);
+
+            // Act – simulate multiple checks during same downtime
+            await service.PingAsync(target, CancellationToken.None);
+            await service.PingAsync(target, CancellationToken.None);
+            await service.PingAsync(target, CancellationToken.None);
+
+            // Assert – only one email sent
+            emailService.Verify(x => x.SendDownAlertAsync(It.IsAny<PingTarget>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task PingAsync_ShouldResendEmail_IfServiceRecoversThenFailsAgain()
+        {
+            // Arrange
+            var handlerMock = new Mock<HttpMessageHandler>();
+            var sequence = new Queue<HttpResponseMessage>(new[]
+            {
+        new HttpResponseMessage(HttpStatusCode.InternalServerError), // Down
+        new HttpResponseMessage(HttpStatusCode.OK),                  // Recovered
+        new HttpResponseMessage(HttpStatusCode.InternalServerError) // Down again
+    });
+
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => sequence.Dequeue());
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            var emailService = new Mock<IEmailAlertService>();
+            var logger = Mock.Of<ILogger<HealthCheckService>>();
+
+            var target = new PingTarget
+            {
+                Name = "Test API3",
+                Url = "https://api.test3.com",
+                MaxRetries = 1
+            };
+
+            var options = Options.Create(new List<PingTarget> { target });
+
+            var service = new HealthCheckService(httpClientFactory.Object, options, emailService.Object, logger);
+
+            // Act – 1st down -> 1st alert
+            await service.PingAsync(target, CancellationToken.None);
+
+            // Act – recovery
+            await service.PingAsync(target, CancellationToken.None);
+
+            // Act – down again -> should trigger new alert
+            await service.PingAsync(target, CancellationToken.None);
+
+            // Assert
+            emailService.Verify(x => x.SendDownAlertAsync(It.IsAny<PingTarget>()), Times.Exactly(2));
         }
     }
 }

--- a/Restless/Services/HealthCheckService.cs
+++ b/Restless/Services/HealthCheckService.cs
@@ -1,16 +1,20 @@
 ﻿using Microsoft.Extensions.Options;
 using Restless.Config;
 using Restless.Interfaces;
+using System.Collections.Concurrent;
 
 namespace Restless.Services
 {
     public class HealthCheckService : BackgroundService
     {
-        private static readonly TimeSpan PingInterval = TimeSpan.FromMinutes(5);
+        // Track which targets have already triggered a down alert
+        private static readonly ConcurrentDictionary<string, bool> alertSentMap = new();
+        private static readonly TimeSpan pingInterval = TimeSpan.FromMinutes(5);
         private readonly IHttpClientFactory httpClientFactory;
         private readonly IOptions<List<PingTarget>> targets;
         private readonly IEmailAlertService emailService;
         private readonly ILogger<HealthCheckService> logger;
+
 
         public HealthCheckService(
         IHttpClientFactory httpClientFactory,
@@ -33,44 +37,48 @@ namespace Restless.Services
 
 
                 // Main loop delay (adjust if needed)
-                await Task.Delay(PingInterval, stoppingToken);
+                await Task.Delay(pingInterval, stoppingToken);
             }
         }
 
         public async Task PingAsync(PingTarget target, CancellationToken cancellationToken)
         {
             var client = httpClientFactory.CreateClient();
+            HttpResponseMessage? response = null;
+            Exception? lastException = null;
 
-            int attempts = 0;
-            bool isUp = false;
-
-            while (attempts < target.MaxRetries && !cancellationToken.IsCancellationRequested)
+            for (int attempt = 1; attempt <= target.MaxRetries; attempt++)
             {
                 try
                 {
-                    var response = await client.GetAsync(target.Url);
+                    response = await client.GetAsync(target.Url, cancellationToken);
                     if (response.IsSuccessStatusCode)
                     {
+                        alertSentMap[target.Url] = false;
                         logger.LogInformation("{Name} responded OK ({StatusCode})", target.Name, response.StatusCode);
-                        isUp = true;
-                        break;
+                        return;
                     }
 
                     logger.LogWarning("{Name} responded with status {StatusCode}", target.Name, response.StatusCode);
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Exception while pinging {Name}", target.Name);
+                    lastException = ex;
+                    logger.LogWarning(ex, "Attempt {Attempt} failed for {Target}", attempt, target.Name);
                 }
 
-                attempts++;
                 await Task.Delay(1000, cancellationToken);
             }
 
-            if (!isUp)
+            if (!alertSentMap.GetOrAdd(target.Url, false))
             {
-                logger.LogError("{Name} is DOWN after {Attempts} attempts", target.Name, target.MaxRetries);
                 await emailService.SendDownAlertAsync(target);
+                alertSentMap[target.Url] = true;
+                logger.LogError("Down alert sent for {Target}", target.Name);
+            }
+            else
+            {
+                logger.LogError("Down alert already sent for {Target}, skipping duplicate alert.", target.Name);
             }
         }
     }


### PR DESCRIPTION
Send only one alert email per service outage; reset alert state if service recovers.